### PR TITLE
Base page template

### DIFF
--- a/sql/seed-data.sql
+++ b/sql/seed-data.sql
@@ -6,24 +6,27 @@ VALUES
 ('frankie', 'Frankie', 'Holzapfel', 'fholzapfel@unomaha.edu', 'pass4', true);
 
 INSERT INTO pothole (lat, lon)
-VALUES (0.0, 0.0);
+VALUES
+    (41.250715, -96.011354),
+    (41.251925, -96.008073),
+    (41.252781, -96.010922),
+    (41.248748, -96.019297),
+    (41.259516, -96.023746),
+    (41.243736, -96.013085);
 
 -- pothole reports
 INSERT INTO pothole_ledger (fk_pothole_id, fk_user_id, state)
-VALUES (1, 1, 5);
-INSERT INTO pothole_ledger (fk_pothole_id, fk_user_id, state)
-VALUES (1, 2, 5);
-INSERT INTO pothole_ledger (fk_pothole_id, fk_user_id, state)
-VALUES (1, 3, 5);
-INSERT INTO pothole_ledger (fk_pothole_id, fk_user_id, state)
-VALUES (1, 4, 5);
-INSERT INTO pothole_ledger (fk_pothole_id, fk_user_id, state)
-VALUES (1, 1, 5);
-INSERT INTO pothole_ledger (fk_pothole_id, fk_user_id, state)
-VALUES (1, 2, 5);
+VALUES
+    (1, 1, 5), (1, 2, 5), (1, 3, 5), (1, 4, 5), (1, 1, 5), (1, 2, 5),
+    (2, 1, 3), (2, 2, 3), (2, 3, 3), (2, 4, 3), (2, 1, 3), (2, 2, 3), (2, 3, 3), (2, 4, 3),
+    (3, 1, 4), (3, 2, 4), (3, 3, 4), (3, 4, 4), (3, 1, 4),
+    (4, 1, 1), (4, 2, 1), (4, 3, 1), (4, 4, 1), (4, 1, 1), (4, 2, 1), (4, 3, 1),
+    (5, 1, 5), (5, 2, 5), (5, 3, 5), (5, 4, 5), (5, 1, 5), (5, 2, 5),
+    (6, 1, 4), (6, 2, 4), (6, 3, 4), (6, 4, 4), (6, 1, 4), (6, 2, 4);
+
 
 -- fixed reports
 INSERT INTO pothole_ledger (fk_pothole_id, fk_user_id, state)
-VALUES (1, 1, 0);
-INSERT INTO pothole_ledger (fk_pothole_id, fk_user_id, state)
-VALUES (1, 2, 0);
+VALUES
+    (1, 1, 0), (1, 2, 0),
+    (5, 3, 0);

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/index.css
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/index.css
@@ -1,0 +1,17 @@
+/*Makes the map take up the rest of the page*/
+body {
+  display: flex;
+  flex-flow: column;
+}
+
+#site-wrapper {
+  flex-grow: 1;
+}
+
+/* Always set the map height explicitly to define the size of the div
+       * element that contains the map. */
+#map {
+  height: 100%;
+  display: block;
+  clear: both;
+}

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/main.css
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/main.css
@@ -1,11 +1,4 @@
-/* Always set the map height explicitly to define the size of the div
-       * element that contains the map. */
-#map {
-  height: 100%;
-  display: block;
-  clear: both;
-}
-/* Optional: Makes the sample page fill the window. */
+/* Makes the page fill the window. */
 html,
 body {
   height: 100%;
@@ -15,7 +8,7 @@ body {
 }
 
 #site-wrapper {
-    height: 80%;
+    height: 100%;
     overflow: hidden;
 }
 

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/main.css
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/main.css
@@ -2,6 +2,8 @@
        * element that contains the map. */
 #map {
   height: 100%;
+  display: block;
+  clear: both;
 }
 /* Optional: Makes the sample page fill the window. */
 html,
@@ -9,10 +11,12 @@ body {
   height: 100%;
   margin: 0;
   padding: 0;
+  font-family: sans-serif;
 }
 
 #site-wrapper {
-    height: 95%;
+    height: 80%;
+    overflow: hidden;
 }
 
 .pothole-info {

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/main.css
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/main.css
@@ -7,11 +7,6 @@ body {
   font-family: sans-serif;
 }
 
-#site-wrapper {
-    height: 100%;
-    overflow: hidden;
-}
-
 .pothole-info {
   clear: both;
 }

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/main.css
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/main.css
@@ -11,6 +11,10 @@ body {
   padding: 0;
 }
 
+#site-wrapper {
+    height: 95%;
+}
+
 .pothole-info {
   clear: both;
 }

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/main.css
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/main.css
@@ -6,13 +6,3 @@ body {
   padding: 0;
   font-family: sans-serif;
 }
-
-.pothole-info {
-  clear: both;
-}
-.alignleft {
-  float: left;
-}
-.alignright {
-  float: right;
-}

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/map.css
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/map.css
@@ -1,0 +1,9 @@
+.pothole-info {
+  clear: both;
+}
+.alignleft {
+  float: left;
+}
+.alignright {
+  float: right;
+}

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/nav.css
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/nav.css
@@ -1,0 +1,37 @@
+.navbar {
+  background-color: #333;
+  display: block;
+  width: 100%;
+  overflow: hidden;
+}
+
+ul.nav-list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.nav-body {
+  float: right;
+}
+
+.nav-header {
+  float:left;
+}
+
+.nav-list li{
+  float: right;
+}
+
+.nav-list li a, .nav-header a {
+  display: block;
+  text-align: center;
+  padding: 15px;
+  text-decoration: none;
+  color: white;
+}
+
+.nav-list li a:hover {
+  background-color: #111;
+}

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/Map.js
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/Map.js
@@ -1,9 +1,9 @@
 function initMap() {
   const infowindow = new google.maps.InfoWindow();
-  // centered on downtown Omaha
+  // centered on UNO
   // TODO: center according to where the user is actually located
   const map = new google.maps.Map(document.getElementById("map"), {
-    center: { lat: 41.2565, lng: -95.9345 },
+    center: { lat: 41.258431, lng: -96.010453 },
     zoom: 16
   });
 

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/Map.js
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/Map.js
@@ -6,7 +6,7 @@ function initMap() {
     center: { lat: 41.2565, lng: -95.9345 },
     zoom: 16
   });
-
+  console.log(map);
   map.data.loadGeoJson("/pothole-geojson/");
 
   map.data.addListener("mouseover", function(event) {

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/Map.js
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/Map.js
@@ -6,7 +6,7 @@ function initMap() {
     center: { lat: 41.2565, lng: -95.9345 },
     zoom: 16
   });
-  console.log(map);
+
   map.data.loadGeoJson("/pothole-geojson/");
 
   map.data.addListener("mouseover", function(event) {

--- a/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/base.html
+++ b/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/base.html
@@ -21,10 +21,9 @@
     {% endblock head_static %}
     {% block head_css %}
       {% block head_css_site %}
-        <link href="{{ STATIC_URL }}css/bootstrap.min.css"
-              rel="stylesheet" media="screen">
-        <link href="{{ STATIC_URL }}css/app.css"
-              rel="stylesheet" media="screen">
+        {% load static %}
+        <link href="{% static 'pothole_reporting/css/nav.css' %}"
+              rel="stylesheet">
       {% endblock head_css_site %}
       {% block head_css_page %}
 
@@ -32,11 +31,20 @@
     {% endblock head_css %}
   </head>
   <body>
-      <header>
+      <div class="header">
         <div class="navbar">
-          Test2 <br><br>test
+          <div class="nav-header">
+            <a href="/">Wheel Time Pothole Reporting</a>
+          </div>
+          <div class="nav-body">
+            <ul class="nav-list">
+              <li><a  href="/">Home</a></li>
+              <li><a  href="/">Submit</a></li>
+              <li><a  href="/">Sign up</a></li>
+            </ul>
+          </div>
         </div>
-      </header>
+      </div class="header">
       <div id="site-wrapper">
         {% block content %}
           This should not be visible

--- a/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/base.html
+++ b/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/base.html
@@ -32,18 +32,20 @@
   </head>
   <body>
       <div class="header">
-        <div class="navbar">
-          <div class="nav-header">
-            <a href="/">Wheel Time Pothole Reporting</a>
+        {% block header_content %}
+          <div class="navbar">
+            <div class="nav-header">
+              <a href="/">Wheel Time Pothole Reporting</a>
+            </div>
+            <div class="nav-body">
+              <ul class="nav-list">
+                <li><a  href="/">Sign up</a></li>
+                <li><a  href="/">Submit</a></li>
+                <li><a  href="/">Home</a></li>
+              </ul>
+            </div>
           </div>
-          <div class="nav-body">
-            <ul class="nav-list">
-              <li><a  href="/">Home</a></li>
-              <li><a  href="/">Submit</a></li>
-              <li><a  href="/">Sign up</a></li>
-            </ul>
-          </div>
-        </div>
+        {% endblock header_content %}
       </div class="header">
       <div id="site-wrapper">
         {% block content %}
@@ -51,7 +53,9 @@
         {% endblock content %}
       </div>
       <div class="footer">
-        Coptyright Wheel Time Systems
+        {% block footer_content %}
+          Copyright Wheel Time Systems
+        {% endblock footer_content %}
       </div>
   </body>
   {% block footer_javascript %}

--- a/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/base.html
+++ b/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/base.html
@@ -2,14 +2,11 @@
 <html>
   <head>
     <title>{% block title %}Test{% endblock title %} | Pothole Reporting</title>
-    <!-- {% block head_favicon %}
-        <link rel="icon" type="image/png"
-              href="{{ STATIC_URL }}images/favicon.ico">
-    {% endblock head_favicon %} -->
+
     {% block head_meta %}
       {% block head_meta_charset %}
         <meta http-equiv="Content-Type"
-              content="text/html; charset=utf-8" />
+              content="charset=utf-8" />
       {% endblock head_meta_charset %}
       {% block head_meta_contentlanguage %}
         <meta http-equiv="Content-Language" value="en-US" />
@@ -19,6 +16,9 @@
               content="width=device-width, initial-scale=1.0">
       {% endblock head_meta_viewport %}
     {% endblock head_meta %}
+    {% block head_static %}
+
+    {% endblock head_static %}
     {% block head_css %}
       {% block head_css_site %}
         <link href="{{ STATIC_URL }}css/bootstrap.min.css"
@@ -34,7 +34,7 @@
   <body>
       <header>
         <div class="navbar">
-          Test
+          Test2 <br><br>test
         </div>
       </header>
       <div id="site-wrapper">

--- a/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/base.html
+++ b/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/base.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{% block title %}Test{% endblock title %} | Pothole Reporting</title>
+    <!-- {% block head_favicon %}
+        <link rel="icon" type="image/png"
+              href="{{ STATIC_URL }}images/favicon.ico">
+    {% endblock head_favicon %} -->
+    {% block head_meta %}
+      {% block head_meta_charset %}
+        <meta http-equiv="Content-Type"
+              content="text/html; charset=utf-8" />
+      {% endblock head_meta_charset %}
+      {% block head_meta_contentlanguage %}
+        <meta http-equiv="Content-Language" value="en-US" />
+      {% endblock head_meta_contentlanguage %}
+      {% block head_meta_viewport %}
+        <meta name="viewport"
+              content="width=device-width, initial-scale=1.0">
+      {% endblock head_meta_viewport %}
+    {% endblock head_meta %}
+    {% block head_css %}
+      {% block head_css_site %}
+        <link href="{{ STATIC_URL }}css/bootstrap.min.css"
+              rel="stylesheet" media="screen">
+        <link href="{{ STATIC_URL }}css/app.css"
+              rel="stylesheet" media="screen">
+      {% endblock head_css_site %}
+      {% block head_css_page %}
+
+      {% endblock head_css_page %}
+    {% endblock head_css %}
+  </head>
+  <body>
+      <header>
+        <div class="navbar">
+          Test
+        </div>
+      </header>
+      <div id="site-wrapper">
+        {% block content %}
+          This should not be visible
+        {% endblock content %}
+      </div>
+      <div class="footer">
+        Coptyright Wheel Time Systems
+      </div>
+  </body>
+  {% block footer_javascript %}
+    {% block footer_javascript_site %}
+
+    {% endblock footer_javascript_site %}
+    {% block footer_javascript_page %}
+
+    {% endblock footer_javascript_page %}
+  {% endblock footer_javascript %}
+</html>

--- a/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
+++ b/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
@@ -8,6 +8,7 @@
 {% block head_css_page %}
   <link rel="stylesheet" href="{% static 'pothole_reporting/css/main.css' %}"/>
   <link rel="stylesheet" href="{% static 'pothole_reporting/css/index.css' %}"/>
+  <link rel="stylesheet" href="{% static 'pothole_reporting/css/index.css' %}"/>
 {% endblock head_css_page %}
 
 {% block content %}

--- a/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
+++ b/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
@@ -6,12 +6,6 @@
 {% endblock head_static %}
 
 {% block head_css_page %}
-  <script src="{% static 'pothole_reporting/js/Map.js' %}"></script>
-  <script
-    src="https://maps.googleapis.com/maps/api/js?key={{ api_key }}&callback=initMap"
-    async
-    defer
-  ></script>
   <link
     rel="stylesheet"
     href="{% static 'pothole_reporting/css/main.css' %}"
@@ -19,10 +13,16 @@
 {% endblock head_css_page %}
 
 {% block content %}
-  <div id="map" style="height: 75%;"></div>
+  <div id="map"></div>
 {% endblock content %}
 
 {% block footer_javascript_page %}
+  <script src="{% static 'pothole_reporting/js/Map.js' %}"></script>
+  <script
+    src="https://maps.googleapis.com/maps/api/js?key={{ api_key }}&callback=initMap"
+    async
+    defer
+  ></script>
 {% endblock footer_javascript_page %}
 <!--
 <!DOCTYPE html>

--- a/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
+++ b/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
@@ -25,27 +25,3 @@
     defer
   ></script>
 {% endblock footer_javascript_page %}
-<!--
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <title>Pothole Reporting</title>
-    <meta name="viewport" content="initial-scale=1.0" />
-    <meta charset="utf-8" />
-    {% load static %}
-    <link
-      rel="stylesheet"
-      href="{% static 'pothole_reporting/css/main.css' %}"
-    />
-    <script src="{% static 'pothole_reporting/js/Map.js' %}"></script>
-    <script
-      src="https://maps.googleapis.com/maps/api/js?key={{ api_key }}&callback=initMap"
-      async
-      defer
-    ></script>
-  </head>
-  <body>
-    <div id="map"></div>
-  </body>
-</html>
- -->

--- a/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
+++ b/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
@@ -6,15 +6,16 @@
 {% endblock head_static %}
 
 {% block head_css_page %}
-  <link
-    rel="stylesheet"
-    href="{% static 'pothole_reporting/css/main.css' %}"
-  />
+  <link rel="stylesheet" href="{% static 'pothole_reporting/css/main.css' %}"/>
+  <link rel="stylesheet" href="{% static 'pothole_reporting/css/index.css' %}"/>
 {% endblock head_css_page %}
 
 {% block content %}
   <div id="map"></div>
 {% endblock content %}
+
+{% block footer_content %}
+{% endblock footer_content %}
 
 {% block footer_javascript_page %}
   <script src="{% static 'pothole_reporting/js/Map.js' %}"></script>

--- a/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
+++ b/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
@@ -8,7 +8,7 @@
 {% block head_css_page %}
   <link rel="stylesheet" href="{% static 'pothole_reporting/css/main.css' %}"/>
   <link rel="stylesheet" href="{% static 'pothole_reporting/css/index.css' %}"/>
-  <link rel="stylesheet" href="{% static 'pothole_reporting/css/index.css' %}"/>
+  <link rel="stylesheet" href="{% static 'pothole_reporting/css/map.css' %}"/>
 {% endblock head_css_page %}
 
 {% block content %}

--- a/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
+++ b/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
@@ -1,3 +1,30 @@
+{% extends 'base.html' %}
+{% block title %}Home{% endblock title %}
+
+{% block head_static %}
+  {% load static %}
+{% endblock head_static %}
+
+{% block head_css_page %}
+  <script src="{% static 'pothole_reporting/js/Map.js' %}"></script>
+  <script
+    src="https://maps.googleapis.com/maps/api/js?key={{ api_key }}&callback=initMap"
+    async
+    defer
+  ></script>
+  <link
+    rel="stylesheet"
+    href="{% static 'pothole_reporting/css/main.css' %}"
+  />
+{% endblock head_css_page %}
+
+{% block content %}
+  <div id="map" style="height: 75%;"></div>
+{% endblock content %}
+
+{% block footer_javascript_page %}
+{% endblock footer_javascript_page %}
+<!--
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -20,3 +47,4 @@
     <div id="map"></div>
   </body>
 </html>
+ -->

--- a/wheel_time_potholes/pothole_reporting/views.py
+++ b/wheel_time_potholes/pothole_reporting/views.py
@@ -49,3 +49,6 @@ def pothole_picture(request):
 def pothole_geojson(request):
     pothole_geojson = get_geojson_potholes(active=True)
     return HttpResponse(pothole_geojson)
+
+def base_template(request, template='base.html'):
+  return direct_to_template(request, template)

--- a/wheel_time_potholes/pothole_reporting/views.py
+++ b/wheel_time_potholes/pothole_reporting/views.py
@@ -49,6 +49,3 @@ def pothole_picture(request):
 def pothole_geojson(request):
     pothole_geojson = get_geojson_potholes(active=True)
     return HttpResponse(pothole_geojson)
-
-def base_template(request, template='base.html'):
-  return direct_to_template(request, template)

--- a/wheel_time_potholes/wheel_time_potholes/settings.py
+++ b/wheel_time_potholes/wheel_time_potholes/settings.py
@@ -56,7 +56,7 @@ ROOT_URLCONF = 'wheel_time_potholes.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'pothole_reporting/templates/pothole_reporting')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
Creates a base page template that can be reused through the site - any page can extend it. No navbar links link to other pages yet, since we have no other pages in master.

Aslo adds css for the base template, and migrates map css to its own file

Also adds seed data for class demo