### PR TITLE
Add historic views of potholes on home page

### DIFF
--- a/wheel_time_potholes/pothole_reporting/potholes/geo_potholes.py
+++ b/wheel_time_potholes/pothole_reporting/potholes/geo_potholes.py
@@ -2,6 +2,7 @@ from geojson import Feature, Point, FeatureCollection, dumps
 from datetime import datetime
 
 from pothole_reporting.models import VwPothole
+from .pothole_queries import vw_pothole_by_date
 
 
 def convert_timestamp(ts):
@@ -12,13 +13,16 @@ def convert_timestamp(ts):
     return datetime.strptime(ts, format)
 
 
-def get_geojson_potholes(active=True):
+def get_geojson_potholes(active=True, date=None):
     """
     If active is true, only return active potholes.
     If active is false, return all potholes.
+    If date is set, then return potholes with ledger information
+    up to the specified date
+    date should be a string of the form: 'YYYY-MM-DD'
     """
-
-    potholes = VwPothole.objects.all()
+    potholes = VwPothole.objects.all() if date is None \
+        else VwPothole.objects.raw(vw_pothole_by_date, {'datetime': '{} 23:59:59'.format(date)})
 
     pothole_features = [Feature(
         geometry=Point((float(pothole.lon), float(pothole.lat)), precision=8),

--- a/wheel_time_potholes/pothole_reporting/potholes/pothole_queries.py
+++ b/wheel_time_potholes/pothole_reporting/potholes/pothole_queries.py
@@ -1,0 +1,41 @@
+vw_pothole_by_date = """   
+   SELECT 
+       p.id,
+       p.lat,
+       p.lon,
+       p.create_date,
+       CASE -- need to add admin check
+           WHEN SUM(CASE
+               WHEN pl.state > 0
+               THEN 1
+               ELSE 0
+           END) >= 5 -- reports until confirm
+           THEN MIN(CASE
+               WHEN pl.state > 0
+               THEN pl.submit_date
+               ELSE '9999-12-31 23:59:59'
+           END)
+           ELSE NULL
+       END AS 'effective_date',
+       CASE -- need to add admin check
+           WHEN SUM(CASE
+               WHEN pl.state = 0
+               THEN 1
+               ELSE 0
+           END) > 5 -- reports until confirm
+           THEN MIN(CASE
+               WHEN pl.state = 0
+               THEN pl.submit_date
+               ELSE '9999-12-31 23:59:59'
+           END)
+           ELSE '9999-12-31 23:59:59'
+       END AS 'fixed_date',
+       SUM(CASE WHEN pl.state > 0 THEN 1 ELSE 0 END) AS 'pothole_reports',
+       SUM(CASE WHEN pl.state = 0 THEN 1 ELSE 0 END) AS 'fixed_reports',
+       AVG(CASE WHEN pl.state > 0 THEN pl.state ELSE null END) AS 'avg_severity'
+   FROM pothole_reporting.pothole p
+       LEFT JOIN pothole_reporting.pothole_ledger pl 
+       ON pl.fk_pothole_id = p.id 
+       WHERE pl.submit_date <= %(datetime)s
+   GROUP BY p.id, p.lat, p.lon, p.create_date; 
+       """

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/index.css
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/index.css
@@ -15,3 +15,12 @@ body {
   display: block;
   clear: both;
 }
+
+.historic-date-container {
+  height: 100%;
+  margin-left: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  float: left;
+}

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/main.css
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/main.css
@@ -6,3 +6,19 @@ body {
   padding: 0;
   font-family: sans-serif;
 }
+
+.subheading-button {
+  margin-right: 10px;
+  background-color: #00c4ff;
+  overflow: hidden;
+  float: left;
+  display: block;
+  text-align: center;
+  padding: 15px;
+  text-decoration: none;
+  color: white;
+}
+
+.subheading-button:hover{
+  background-color: #54d7ff;
+}

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/submission.css
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/css/submission.css
@@ -43,22 +43,6 @@ select {
   top: 8px;
 }
 
-.image-nav {
-  margin-right: 10px;
-  background-color: #00c4ff;
-  overflow: hidden;
-  float: left;
-  display: block;
-  text-align: center;
-  padding: 15px;
-  text-decoration: none;
-  color: white;
-}
-
-.image-nav:hover {
-  background-color: #54d7ff;
-}
-
 #picture-submit {
   flex-grow: 0;
 }

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/IndexMap.js
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/IndexMap.js
@@ -1,8 +1,22 @@
+var map;
+
+function reloadGeoJson(event) {
+  date = $("#historic-date").val();
+  if (date) {
+    map.data.forEach(function (feature) {
+      map.data.remove(feature);
+    });
+    map.data.loadGeoJson("/pothole-geojson/?active=true&date=" + date);
+  } else {
+    alert("Please specify a date");
+  }
+}
+
 function initMap() {
   const infoWindow = new google.maps.InfoWindow();
   // centered on UNO
   // TODO: center according to where the user is actually located
-  const map = new google.maps.Map(document.getElementById("map"), {
+  map = new google.maps.Map(document.getElementById("map"), {
     center: { lat: 41.258431, lng: -96.010453 },
     zoom: 16,
   });
@@ -33,3 +47,16 @@ function initMap() {
     infoWindow.open(map);
   });
 }
+
+$("#change-to-historic").bind("click", function () {
+  $("#change-to-historic").replaceWith(
+    `<a href="#" onclick="return reloadGeoJson(this)" id="load-historic" class="subheading-button">Load Historic View</a>`
+  );
+  $("#historic-label").replaceWith(`<p id="historic-label" class="alignleft">
+                                    Select a date to view the past pothole status</p>`);
+  // min should be set to the first date the application records pothole data for
+  $("#historic-label").after(`<div class="historic-date-container">
+                                <input type="date" id="historic-date" name="historic-date"
+                                min="2020-04-01">
+                              </div>`);
+});

--- a/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
+++ b/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/index.html
@@ -11,6 +11,13 @@
   <link rel="stylesheet" href="{% static 'pothole_reporting/css/map.css' %}"/>
 {% endblock head_css_page %}
 
+{% block subheader_content %}
+  <div id="historic-view">
+    <a href="#" type="button" class="subheading-button" id="change-to-historic">Historic View</a>
+    <p class="alignleft" id="historic-label">Click here to view the active potholes on a past date</p>
+  </div>
+{% endblock subheader_content %}
+
 {% block content %}
   <div id="map"></div>
 {% endblock content %}
@@ -19,6 +26,7 @@
 {% endblock footer_content %}
 
 {% block footer_javascript_page %}
+  <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
   <script src="{% static 'pothole_reporting/js/IndexMap.js' %}"></script>
   <script
     src="https://maps.googleapis.com/maps/api/js?key={{ api_key }}&callback=initMap"

--- a/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/submission.html
+++ b/wheel_time_potholes/pothole_reporting/templates/pothole_reporting/submission.html
@@ -13,7 +13,7 @@
 
 {% block subheader_content %}
   <div id="picture-submit">
-    <a class="image-nav" href="{% url 'pothole-picture' %}">Image Submission</a>
+    <a class="subheading-button" href="{% url 'pothole-picture' %}">Image Submission</a>
     <p class="alignleft">Click here to submit a geotagged image of a pothole</p>
   </div>
 {% endblock subheader_content %}

--- a/wheel_time_potholes/pothole_reporting/views.py
+++ b/wheel_time_potholes/pothole_reporting/views.py
@@ -40,6 +40,7 @@ def submit_pothole(request):
 
         return HttpResponse("SUCCESS")
 
+
 def update_pothole(request):
     if request.method == 'GET':
         return render(request,
@@ -61,6 +62,7 @@ def update_pothole(request):
             print("Transaction failed")
 
         return HttpResponse("SUCCESS")
+
 
 def pothole_picture(request):
     text = ""
@@ -97,6 +99,7 @@ def pothole_geojson(request):
     if request.method == 'GET':
         active = request.GET.get('active')
         active = (active is not None and active.lower() != "false")
-        pothole_geojson = get_geojson_potholes(active=active)
+        date = request.GET.get('date')
+        pothole_geojson = get_geojson_potholes(active=active, date=date)
     return HttpResponse(pothole_geojson)
 


### PR DESCRIPTION
Query database and use ledger entries on or before the date specified, showing the active potholes on that day.
- Reuse the vw_pothole view with an added date parameter to run a raw query to get the dated view

Add a subheading on the home page to view historic pothole data
- Clicking the "Historic View" button adds the date entry field and allows for submission with the "Load Historic View" button
- This was done because most users probably wouldn't be concerned about the historic view, so I figured initially hiding the date entry would make the page look cleaner.
