### PR TITLE
Pothole date format

### DIFF
--- a/wheel_time_potholes/pothole_reporting/potholes/geo_potholes.py
+++ b/wheel_time_potholes/pothole_reporting/potholes/geo_potholes.py
@@ -36,7 +36,7 @@ def get_geojson_potholes(active=True, date=None):
                                 and convert_timestamp(pothole.fixed_date) > datetime.utcnow(),
                     "fixed_date": str(pothole.fixed_date),
                     "fixed": pothole.fixed_date and convert_timestamp(pothole.fixed_date) < datetime.utcnow(),
-                    "severity": str(pothole.avg_severity),
+                    "severity": str(('%f' % round(pothole.avg_severity, 2)).rstrip('.0')),
                     "utcnow": str(datetime.utcnow())
                     })
         for pothole in potholes

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/IndexMap.js
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/IndexMap.js
@@ -40,7 +40,7 @@ function formatPotholeDate(timestamp) {
   } else {
     daysSince = differenceDays + " days ago";
   }
-  return `${date.getMonth()}/${date.getDate()}/${date.getFullYear()} (${daysSince})`;
+  return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()} (${daysSince})`;
 }
 
 function initMap() {

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/SubmissionMap.js
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/SubmissionMap.js
@@ -42,6 +42,36 @@ function getCookie(name) {
   return cookieValue;
 }
 
+function formatPotholeDate(timestamp) {
+  // All dates are handled in UTC time
+  var dateElements = timestamp.split(/[- :]/);
+  var date = new Date(
+    Date.UTC(
+      dateElements[0],
+      dateElements[1] - 1,
+      dateElements[2],
+      dateElements[3],
+      dateElements[4],
+      dateElements[5]
+    )
+  );
+
+  // compute number of days between submission and current date
+  var today = Date.now();
+  var differenceTime = today - date.getTime();
+  var differenceDays = parseInt(differenceTime / (1000 * 3600 * 24));
+
+  var daysSince;
+  if (differenceDays == 0) {
+    daysSince = "today";
+  } else if (differenceDays == 1) {
+    daysSince = "1 day ago";
+  } else {
+    daysSince = differenceDays + " days ago";
+  }
+  return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()} (${daysSince})`;
+}
+
 function initMap(latlng={ lat: 41.258431, lng: -96.010453 }) {
   map = new google.maps.Map(document.getElementById("map"), {
     center: latlng,
@@ -102,26 +132,26 @@ function initMap(latlng={ lat: 41.258431, lng: -96.010453 }) {
     if (feature.getProperty("active")) {
       content +=
       "<p>Active since: " +
-      feature.getProperty("effective_date") +
+      formatPotholeDate(feature.getProperty("effective_date")) +
       "</p>";
     } else if (feature.getProperty("fixed")) {
       content +=
       "<p>Fixed since: " +
-      feature.getProperty("fixed_date") +
+      formatPotholeDate(feature.getProperty("fixed_date")) +
       "</p>";
     } else {
+      // create_date is a mysql datetime, so must remove timezone information
+      var dateNoTZ = feature.getProperty("create_date").split(/[+]/)[0]
       content +=
       "<p>Submitted: " +
-      feature.getProperty("create_date") +
+      formatPotholeDate(dateNoTZ) +
       "</p>";
     }
     content +=
-      '<p class="alignleft">Confirmations: ' +
-      feature.getProperty("pothole_reports") +
-      "</p>" +
-      '<p class="alignright">Fixed: ' +
-      feature.getProperty("fixed_reports") +
-      `</p>
+      `<p class="alignleft">Confirmations: ${feature.getProperty("pothole_reports")}
+      </p>
+      <p class="alignright">Fixed: ${feature.getProperty("fixed_reports")}
+      </p>
       </div>
       <div class='row'>
         <input onclick="return onConfirm(this);" class="alignleft" id="confirm-button" type="submit" value="Confirm"/>

--- a/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/SubmissionMap.js
+++ b/wheel_time_potholes/pothole_reporting/static/pothole_reporting/js/SubmissionMap.js
@@ -23,6 +23,25 @@ function reloadGeoJson() {
   });
 }
 
+// get the cookie in order to extract information, such as the csrf token
+function getCookie(name) {
+  var cookieValue = null;
+  if (document.cookie && document.cookie != "") {
+    var cookies = document.cookie.split(";");
+    for (var i = 0; i < cookies.length; i++) {
+      var cookie = jQuery.trim(cookies[i]);
+      // Does this cookie string begin with the name we want?
+      if (cookie.substring(0, name.length + 1) == name + "=") {
+        cookieValue = decodeURIComponent(
+          cookie.substring(name.length + 1)
+        );
+        break;
+      }
+    }
+  }
+  return cookieValue;
+}
+
 function initMap(latlng={ lat: 41.258431, lng: -96.010453 }) {
   map = new google.maps.Map(document.getElementById("map"), {
     center: latlng,
@@ -39,27 +58,26 @@ function initMap(latlng={ lat: 41.258431, lng: -96.010453 }) {
     infoWindow.close();
 
     var content =
-      '<div class="submission-window">' +
-      "<h4>Submit a new Pothole</h4>" +
-      "<form " +
-      'id="pothole-form" ' +
-      'action="{% url "submit" %}" ' +
-      'method="post"' +
-      ">" +
-      '<div id="severity">' +
-      '<label class="select-label">Severity:</label>' +
-      '<select id="state-select" name="state" size="5">' +
-      '<option class="severity-select" id="select-1" value=1>1</option>' +
-      '<option class="severity-select" id="select-2" value=2>2</option>' +
-      '<option class="severity-select" id="select-3" value=3>3</option>' +
-      '<option class="severity-select" id="select-4" value=4>4</option>' +
-      '<option class="severity-select" id="select-5" value=5>5</option>' +
-      "</select>" +
-      "</div>" +
-      "<br/>" +
-      '<input onclick="return onSubmit(this);" class="alignright" id="submit-button" type="submit" value="Submit pothole"/>' +
-      "</form>" +
-      "</div>";
+    `<div class="submission-window">
+      <h4>Submit a new Pothole</h4>
+      <form 
+      id="pothole-form"
+      action="{% url "submit" %}"
+      method="post">
+        <div id="severity">
+          <label class="select-label">Severity:</label>
+          <select id="state-select" name="state" size="5">
+            <option class="severity-select" id="select-1" value=1>1</option>
+            <option class="severity-select" id="select-2" value=2>2</option>
+            <option class="severity-select" id="select-3" value=3>3</option>
+            <option class="severity-select" id="select-4" value=4>4</option>
+            <option class="severity-select" id="select-5" value=5>5</option>
+          </select>
+        </div>
+        <br/>
+        <input onclick="return onSubmit(this);" class="alignright" id="submit-button" type="submit" value="Submit pothole"/>
+      </form>
+    </div>`;
 
     // Create a new InfoWindow.
     infoWindow = new google.maps.InfoWindow({
@@ -103,13 +121,13 @@ function initMap(latlng={ lat: 41.258431, lng: -96.010453 }) {
       "</p>" +
       '<p class="alignright">Fixed: ' +
       feature.getProperty("fixed_reports") +
-      "</p>" +
-      "</div>" +
-      "<div class='row'>" +
-      '<input onclick="return onConfirm(this);" class="alignleft" id="confirm-button" type="submit" value="Confirm"/>' +
-      '<input onclick="return onUpdate(this, true);" class="alignright" id="fixed-button" type="submit" value="Fixed"/>' +
-      "</div>" +
-      "</div>";
+      `</p>
+      </div>
+      <div class='row'>
+        <input onclick="return onConfirm(this);" class="alignleft" id="confirm-button" type="submit" value="Confirm"/>
+        <input onclick="return onUpdate(this, true);" class="alignright" id="fixed-button" type="submit" value="Fixed"/>
+      </div>
+      </div>`;
     infoWindow.setContent(content);
     infoWindow.setPosition(event.feature.getGeometry().get());
     infoWindow.setOptions({ pixelOffset: new google.maps.Size(0, -30) });
@@ -119,21 +137,21 @@ function initMap(latlng={ lat: 41.258431, lng: -96.010453 }) {
 
 function onConfirm(event) {
   let content =
-      '<div class="submission-window">' +
-      "<h4>Confirm this Pothole</h4>" +
-      '<div id="severity">' +
-      '<label class="select-label">Severity:</label>' +
-      '<select id="state-select" name="state" size="5">' +
-      '<option class="severity-select" id="select-1" value=1>1</option>' +
-      '<option class="severity-select" id="select-2" value=2>2</option>' +
-      '<option class="severity-select" id="select-3" value=3>3</option>' +
-      '<option class="severity-select" id="select-4" value=4>4</option>' +
-      '<option class="severity-select" id="select-5" value=5>5</option>' +
-      "</select>" +
-      "</div>" +
-      "<br/>" +
-      '<input onclick="return onUpdate(this);" class="alignright" id="submit-button" type="submit" value="Confirm pothole"/>' +
-      "</div>";
+      `<div class="submission-window">
+        <h4>Confirm this Pothole</h4>
+        <div id="severity">
+          <label class="select-label">Severity:</label>
+          <select id="state-select" name="state" size="5">
+            <option class="severity-select" id="select-1" value=1>1</option>
+            <option class="severity-select" id="select-2" value=2>2</option>
+            <option class="severity-select" id="select-3" value=3>3</option>
+            <option class="severity-select" id="select-4" value=4>4</option>
+            <option class="severity-select" id="select-5" value=5>5</option>
+          </select>
+        </div>
+        <br/>
+        <input onclick="return onUpdate(this);" class="alignright" id="submit-button" type="submit" value="Confirm pothole"/>
+      </div>`;
   $(event).parent().parent().html(content)
 }
 
@@ -156,24 +174,6 @@ function onUpdate(event, fixed=false) {
     url: "/update/",
     data: potholeData,
     beforeSend: function (xhr, settings) {
-      // get the cookie in order to extract the csrf token
-      function getCookie(name) {
-        var cookieValue = null;
-        if (document.cookie && document.cookie != "") {
-          var cookies = document.cookie.split(";");
-          for (var i = 0; i < cookies.length; i++) {
-            var cookie = jQuery.trim(cookies[i]);
-            // Does this cookie string begin with the name we want?
-            if (cookie.substring(0, name.length + 1) == name + "=") {
-              cookieValue = decodeURIComponent(
-                cookie.substring(name.length + 1)
-              );
-              break;
-            }
-          }
-        }
-        return cookieValue;
-      }
       // add the csrf token to the submission header
       xhr.setRequestHeader("X-CSRFToken", getCookie("csrftoken"));
     },
@@ -206,24 +206,6 @@ function onSubmit(event) {
       url: "/submit/",
       data: potholeData,
       beforeSend: function (xhr, settings) {
-        // get the cookie in order to extract the csrf token
-        function getCookie(name) {
-          var cookieValue = null;
-          if (document.cookie && document.cookie != "") {
-            var cookies = document.cookie.split(";");
-            for (var i = 0; i < cookies.length; i++) {
-              var cookie = jQuery.trim(cookies[i]);
-              // Does this cookie string begin with the name we want?
-              if (cookie.substring(0, name.length + 1) == name + "=") {
-                cookieValue = decodeURIComponent(
-                  cookie.substring(name.length + 1)
-                );
-                break;
-              }
-            }
-          }
-          return cookieValue;
-        }
         // add the csrf token to the submission header
         xhr.setRequestHeader("X-CSRFToken", getCookie("csrftoken"));
       },


### PR DESCRIPTION
Change the date displayed for each pothole infoWindow to: ______ since: MM/DD/YYYY (x days ago)
- Reformatted the multiline js strings to template literals 
- Factored out `getCookie()` function in SubmissionMap
- Applied prettier formatting to part of IndexMap/SubmissionMap, as it can make block strings more unreadable, so they were left unformatted

Also, I found that in the `vw_pothole` view, `create_date` is stored as a `datetime`, while `effective_date` and `fixed_date` are `charfields`. This creates a bit of an inconsistency, such as when accessing them in string format. For this, I've just put a work around in SubmissionMap, but we may consider changing that in the future.